### PR TITLE
ENH: models: add de-serialization and refactor signable arch

### DIFF
--- a/src/main/java/io/in_toto/keys/Signature.java
+++ b/src/main/java/io/in_toto/keys/Signature.java
@@ -20,4 +20,8 @@ public class Signature
         this.keyid = keyid;
         this.sig = sig;
     }
+
+    public String getKeyId() {
+        return this.keyid;
+    }
 }

--- a/src/main/java/io/in_toto/models/LinkSignable.java
+++ b/src/main/java/io/in_toto/models/LinkSignable.java
@@ -1,0 +1,65 @@
+/*
+ * package-private class representing the signable payload of the in-toto link
+ * metadata.
+ */
+package io.in_toto.models;
+
+import io.in_toto.models.Artifact;
+import io.in_toto.models.Artifact.ArtifactHash;
+import io.in_toto.keys.Signature;
+import io.in_toto.models.LinkSignable;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+
+class LinkSignable
+    extends Signable {
+
+    HashMap<String, ArtifactHash> materials;
+    HashMap<String, ArtifactHash> products;
+    HashMap<String, String>  byproducts;
+    HashMap<String, String>  environment;
+    ArrayList<String> command;
+    String name;
+
+    LinkSignable(HashMap<String, ArtifactHash> materials,
+            HashMap<String, ArtifactHash> products, String name,
+            HashMap<String, String> environment, ArrayList<String> command,
+            HashMap<String, String> byproducts) {
+
+        super();
+
+        if (materials == null)
+            materials = new HashMap<String, ArtifactHash>();
+
+        if (products == null)
+            products = new HashMap<String, ArtifactHash>();
+
+        //FIXME: probably warn about this would be a good idea
+        if (name == null)
+           name = "step";
+
+        if (environment == null)
+            environment = new HashMap<String, String>();
+
+        if (command == null)
+            command = new ArrayList<String>();
+
+        if (byproducts == null)
+            byproducts = new HashMap<String, String>();
+
+        this.materials = materials;
+        this.products = products;
+        this.name = name;
+        this.environment = environment;
+        this.command = command;
+        this.byproducts = byproducts;
+    }
+
+    @Override
+    public String getType() {
+        return "link";
+    }
+}
+
+

--- a/src/main/java/io/in_toto/models/Metablock.java
+++ b/src/main/java/io/in_toto/models/Metablock.java
@@ -3,6 +3,7 @@ package io.in_toto.models;
 import java.util.ArrayList;
 
 import java.io.FileWriter;
+import java.io.Writer;
 import java.io.IOException;
 
 import io.in_toto.keys.Key;
@@ -23,9 +24,9 @@ import org.bouncycastle.crypto.CryptoException;
  * - A signed field, with the signable portion of a piece of metadata.
  * - A signatures field, a list of the signatures on this metadata.
  */
-abstract class Metablock
+abstract class Metablock<S extends Signable>
 {
-    Signable signed;
+    S signed;
     ArrayList<Signature> signatures;
 
     /**
@@ -33,7 +34,7 @@ abstract class Metablock
      *
      * Ensures that, at the least, there is an empty list of signatures.
      */
-    public Metablock(Signable signed, ArrayList<Signature> signatures) {
+    public Metablock(S signed, ArrayList<Signature> signatures) {
         this.signed = signed;
 
         if (signatures == null)
@@ -48,16 +49,37 @@ abstract class Metablock
      */
     public void dump(String filename) {
         FileWriter writer = null;
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
         try{
             writer = new FileWriter(filename);
-            writer.write(gson.toJson(this));
-            writer.flush();
+            dump(writer);
             writer.close();
         } catch (IOException e) {
-            System.out.println("Couldn't serialize object: " + e.toString());
+            throw new RuntimeException("Couldn't serialize object: " + e.toString());
         }
+    }
+
+    /**
+     * Serialize the current metadata into a writer
+     *
+     * @param writer the target writer
+     */
+    public void dump(Writer writer)
+        throws IOException {
+
+        writer.write(dumpString());
+        writer.flush();
+    }
+
+    /**
+     * Serialize the current metadata to a string
+     *
+     *
+     * @return a JSON string representation of the metadata instance
+     */
+    public String dumpString() {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        return gson.toJson(this);
     }
 
     /**

--- a/src/test/java/io/in_toto/models/LinkTest.java
+++ b/src/test/java/io/in_toto/models/LinkTest.java
@@ -140,5 +140,21 @@ class LinkTest
         File fl = new File("dump.link");
         assertTrue(fl.exists());
         fl.delete();
-    }    
+    }
+
+    @Test
+    @DisplayName("Validate link serialization and de-serialization")
+    public void testLinkDeSerialization()
+    {
+
+        Link testLink = new Link(null, null, "sometestname",
+                null, null, null);
+
+        String jsonString = testLink.dumpString();
+        Link newLink = Link.read(jsonString);
+
+        assertTrue(newLink.getName() != null);
+        assertEquals(testLink.getName(), newLink.getName());
+    }
+
 }


### PR DESCRIPTION
The signable architecture wasn't allowing users to de-serialize metadata using Gson.
This pull request adds the following:

- [x] Re-structure the class architecture to genericize the Signed propertie in the Metablock object
- [x] Re-factor the signable class to its own package-private implin order to instantiate it within the Link object
- [x] Add a convenience read method on the Link class using Gson
- [x] Add a very simple test for this.