### PR TITLE
Adopt reference implementation canonical json encoding

### DIFF
--- a/src/main/java/io/github/in_toto/keys/RSAKey.java
+++ b/src/main/java/io/github/in_toto/keys/RSAKey.java
@@ -201,7 +201,7 @@ public class RSAKey
             this.kpr = null;
         }
 
-        byte[] JSONrepr = this.JSONEncode().getBytes();
+        byte[] JSONrepr = this.JSONEncodeCanonical(false).getBytes();
 
         if (privateBackup != null)
             this.keyval.put("private", privateBackup);

--- a/src/main/java/io/github/in_toto/lib/JSONEncoder.java
+++ b/src/main/java/io/github/in_toto/lib/JSONEncoder.java
@@ -29,29 +29,29 @@ public interface JSONEncoder
     // FIXME canonicalization we need to unescape the escaped strings because someone at Google decided
     // to not use their own serializer architecture to perform the escaping :/
     static JsonElement canonicalize(JsonElement src) {
-      if (src instanceof JsonArray) {
-        // Canonicalize each element of the array
-        JsonArray srcArray = (JsonArray)src;
-        JsonArray result = new JsonArray();
-        for (int i = 0; i < srcArray.size(); i++) {
-          result.add(canonicalize(srcArray.get(i)));
+        if (src instanceof JsonArray) {
+            // Canonicalize each element of the array
+            JsonArray srcArray = (JsonArray)src;
+            JsonArray result = new JsonArray();
+            for (int i = 0; i < srcArray.size(); i++) {
+                result.add(canonicalize(srcArray.get(i)));
+            }
+            return result;
+        } else if (src instanceof JsonObject) {
+            // Sort the attributes by name, and the canonicalize each element of the object
+            JsonObject srcObject = (JsonObject)src;
+            JsonObject result = new JsonObject();
+            TreeSet<String> attributes = new TreeSet<>();
+            for (Map.Entry<String, JsonElement> entry : srcObject.entrySet()) {
+                attributes.add(entry.getKey());
+            }
+            for (String attribute : attributes) {
+                result.add(attribute, canonicalize(srcObject.get(attribute)));
+            }
+            return result;
+        } else {
+            return src;
         }
-        return result;
-      } else if (src instanceof JsonObject) {
-        // Sort the attributes by name, and the canonicalize each element of the object
-        JsonObject srcObject = (JsonObject)src;
-        JsonObject result = new JsonObject();
-        TreeSet<String> attributes = new TreeSet<>();
-        for (Map.Entry<String, JsonElement> entry : srcObject.entrySet()) {
-          attributes.add(entry.getKey());
-        }
-        for (String attribute : attributes) {
-          result.add(attribute, canonicalize(srcObject.get(attribute)));
-        }
-        return result;
-      } else {
-        return src;
-      }
     }
 
     default public String JSONEncode() {

--- a/src/main/java/io/github/in_toto/lib/JSONEncoder.java
+++ b/src/main/java/io/github/in_toto/lib/JSONEncoder.java
@@ -140,13 +140,11 @@ public interface JSONEncoder
      * @return A canonical json encoded string of the calling object.
      */
     default public String JSONEncodeCanonical(boolean serializeNulls) {
-        Gson gson = new GsonBuilder()
-            .disableHtmlEscaping()
-            .create();
-
+        GsonBuilder gsonBuilder = new GsonBuilder();
         if (serializeNulls) {
-            gson.serializeNulls();
+            gsonBuilder.serializeNulls();
         }
+        Gson gson = gsonBuilder.disableHtmlEscaping().create();
 
         return canonicalize(gson.toJsonTree(this));
     }

--- a/src/main/java/io/github/in_toto/lib/JSONEncoder.java
+++ b/src/main/java/io/github/in_toto/lib/JSONEncoder.java
@@ -7,9 +7,10 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializer;
 import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonPrimitive;
 
 
 import java.util.ArrayList;
@@ -24,43 +25,129 @@ import java.lang.reflect.Type;
  * can be used for hashing.
  */
 public interface JSONEncoder
+
 {
-    // taken from: https://stackoverflow.com/questions/12584744/canonicalizing-json-files
-    // FIXME canonicalization we need to unescape the escaped strings because someone at Google decided
-    // to not use their own serializer architecture to perform the escaping :/
-    static JsonElement canonicalize(JsonElement src) {
-        if (src instanceof JsonArray) {
-            // Canonicalize each element of the array
-            JsonArray srcArray = (JsonArray)src;
-            JsonArray result = new JsonArray();
-            for (int i = 0; i < srcArray.size(); i++) {
-                result.add(canonicalize(srcArray.get(i)));
-            }
-            return result;
-        } else if (src instanceof JsonObject) {
-            // Sort the attributes by name, and the canonicalize each element of the object
-            JsonObject srcObject = (JsonObject)src;
-            JsonObject result = new JsonObject();
-            TreeSet<String> attributes = new TreeSet<>();
-            for (Map.Entry<String, JsonElement> entry : srcObject.entrySet()) {
-                attributes.add(entry.getKey());
-            }
-            for (String attribute : attributes) {
-                result.add(attribute, canonicalize(srcObject.get(attribute)));
-            }
-            return result;
-        } else {
-            return src;
-        }
+    /**
+     * Static helper method to canonicalize a json string by escaping the
+     * double quotes `"` and backslash `\` characters using the backslash
+     * escape character `\`, based on the securesystemslib implementation used
+     * in the in-toto reference implementation, see:
+     * https://github.com/secure-systems-lab/securesystemslib/blob/v0.11.2/securesystemslib/formats.py#L688
+     *
+     * @param src Source string to be canonicalized
+     *
+     * @return A canonicalized String
+     */
+    static String canonicalizeString(String src) {
+        String pattern = "([\\\\\"])";
+        return String.format("\"%s\"", src.replaceAll(pattern, "\\\\$1"));
     }
 
-    default public String JSONEncode() {
+    /**
+     * Static helper method to recursively create a canonical json encoded
+     * string of the passed JsonElement, based on the securesystemslib
+     * implementation used in the in-toto reference implementation, see:
+     * https://github.com/secure-systems-lab/securesystemslib/blob/v0.11.2/securesystemslib/formats.py#L712
+     *
+     * @param src Source JsonElement to be traversed and encoded
+     *
+     * @return A canonical json encoded string of the passed JsonElement.
+     */
+    static String canonicalize(JsonElement src) {
+        String result =  new String();
+        if (src instanceof JsonArray) {
+            // Canonicalize each element of the array
+            result += "[";
+            JsonArray array = (JsonArray) src;
+            for (int i = 0; i < array.size(); i++) {
+                result += canonicalize(array.get(i));
+
+                if (i < array.size() - 1) {
+                  result += ",";
+                }
+            }
+            result += "]";
+
+        } else if (src instanceof JsonObject) {
+            result += "{";
+
+            JsonObject obj = (JsonObject)src;
+            // Create an ordered list of the JsonObject's keys
+            TreeSet<String> keys = new TreeSet<>();
+            for (Map.Entry<String, JsonElement> entry : obj.entrySet()) {
+                keys.add(entry.getKey());
+            }
+
+            // Canonicalize json object
+            int i = 0;
+            for (String key : keys) {
+                // NOTE: It is okay to only call `canonicalizeString` (instead
+                // of `canonicalize` like in the reference implementation)
+                // because we know that the keys are always strings.
+                result += canonicalizeString(key);
+                result += ":";
+                result += canonicalize(obj.get(key));
+
+                if (i < keys.size() - 1) {
+                    result += ",";
+                }
+                i++;
+            }
+            result += "}";
+
+        } else if (src instanceof JsonNull) {
+            result += "null";
+
+        } else if (src instanceof JsonPrimitive) {
+            JsonPrimitive primitive = (JsonPrimitive) src;
+
+            if (primitive.isNumber()) {
+                result += String.format("%d", primitive.getAsInt());
+
+            } else if (primitive.isBoolean()) {
+                result += primitive.getAsString();
+
+            } else if (primitive.isString()) {
+                String decodedPrimitive = new GsonBuilder()
+                        .disableHtmlEscaping()
+                        .create()
+                        .fromJson(primitive, String.class);
+                result += canonicalizeString(decodedPrimitive);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Method to create a canonical json encoded string of the calling object
+     * using the specification at http://wiki.laptop.org/go/Canonical_JSON.
+     *
+     * Attributes with `null` values are encoded as `"<name>": null`.
+     *
+     * @return A canonical json encoded string of the calling object.
+     */
+    default public String JSONEncodeCanonical() {
+        return this.JSONEncodeCanonical(true);
+    }
+
+    /**
+     * Method to create a canonical json encoded string of the calling object
+     * using the specification at http://wiki.laptop.org/go/Canonical_JSON
+     *
+     * @param serializeNulls if true attributes with null values are
+     * are encoded as `"<name>": null` and omitted otherwise.
+     *
+     * @return A canonical json encoded string of the calling object.
+     */
+    default public String JSONEncodeCanonical(boolean serializeNulls) {
         Gson gson = new GsonBuilder()
             .disableHtmlEscaping()
             .create();
 
-        // Note the replace call: we need to unescape characters that are disallowed in the regular
-        // JSON.
-        return gson.toJson(canonicalize(gson.toJsonTree(this))).replace("\\n", "\n");
+        if (serializeNulls) {
+            gson.serializeNulls();
+        }
+
+        return canonicalize(gson.toJsonTree(this));
     }
 }

--- a/src/main/java/io/github/in_toto/lib/NumericJSONSerializer.java
+++ b/src/main/java/io/github/in_toto/lib/NumericJSONSerializer.java
@@ -1,0 +1,31 @@
+package io.github.in_toto.lib;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+
+
+/**
+ * A custom implementation of the gson JsonSerializer to convert numeric values
+ * to non-floating point numbers when serializing JSON.
+ *
+ * This is required to handle generic data, such as `byproducts` or
+ * `environment`, where the type of the contained values is not declared. Gson
+ * treats any numeric value, with generic type in the target data structure as
+ * double. However, the in-toto reference implementation does not allow
+ * floating point numbers in JSON-formatted metadata.
+ *
+ */
+public class NumericJSONSerializer implements JsonSerializer<Double> {
+    public JsonElement serialize(Double src, Type typeOfSrc,
+            JsonSerializationContext context) {
+        if(src == src.longValue()) {
+            return new JsonPrimitive(src.longValue());
+        }
+
+        return new JsonPrimitive(src);
+    }
+}

--- a/src/main/java/io/github/in_toto/models/Link.java
+++ b/src/main/java/io/github/in_toto/models/Link.java
@@ -35,8 +35,8 @@ public class Link extends Metablock<LinkSignable>
      */
     public Link(HashMap<String, ArtifactHash> materials,
             HashMap<String, ArtifactHash> products, String name,
-            HashMap<String, String> environment, ArrayList<String> command,
-            HashMap<String, String> byproducts) {
+            HashMap<String, Object> environment, ArrayList<String> command,
+            HashMap<String, Object> byproducts) {
         super(null, null);
         LinkSignable signable = new LinkSignable(
                 materials, products, name, environment, command, byproducts);
@@ -95,11 +95,11 @@ public class Link extends Metablock<LinkSignable>
         return ((LinkSignable)this.signed).name;
     }
 
-    public void setEnvironment(HashMap<String, String> environment) {
+    public void setEnvironment(HashMap<String, Object> environment) {
         ((LinkSignable)this.signed).environment = environment;
     }
 
-    public HashMap<String, String> getEnvironment() {
+    public HashMap<String, Object> getEnvironment() {
         return ((LinkSignable)this.signed).environment;
     }
 
@@ -111,11 +111,11 @@ public class Link extends Metablock<LinkSignable>
         return ((LinkSignable)this.signed).command;
     }
 
-    public void setByproducts(HashMap<String, String> byproducts) {
+    public void setByproducts(HashMap<String, Object> byproducts) {
         ((LinkSignable)this.signed).byproducts = byproducts;
     }
 
-    public HashMap<String, String> getByproducts() {
+    public HashMap<String, Object> getByproducts() {
         return ((LinkSignable)this.signed).byproducts;
     }
 

--- a/src/main/java/io/github/in_toto/models/LinkSignable.java
+++ b/src/main/java/io/github/in_toto/models/LinkSignable.java
@@ -17,8 +17,14 @@ class LinkSignable
 
     HashMap<String, ArtifactHash> materials;
     HashMap<String, ArtifactHash> products;
-    HashMap<String, Object>  byproducts;
-    HashMap<String, Object>  environment;
+    // NOTE: Caution when dealing with numeric values!
+    // Since gson does not know the type of the target, it will
+    // store any numeric value as `Double`, e.g.:
+    // {"byproducts": {"return-value": 1}}
+    // is parsed as
+    // {"byproducts": {"return-value": 1.0}}
+    HashMap<String, Object> byproducts;
+    HashMap<String, Object> environment;
     ArrayList<String> command;
     String name;
 

--- a/src/main/java/io/github/in_toto/models/LinkSignable.java
+++ b/src/main/java/io/github/in_toto/models/LinkSignable.java
@@ -17,15 +17,15 @@ class LinkSignable
 
     HashMap<String, ArtifactHash> materials;
     HashMap<String, ArtifactHash> products;
-    HashMap<String, String>  byproducts;
-    HashMap<String, String>  environment;
+    HashMap<String, Object>  byproducts;
+    HashMap<String, Object>  environment;
     ArrayList<String> command;
     String name;
 
     LinkSignable(HashMap<String, ArtifactHash> materials,
             HashMap<String, ArtifactHash> products, String name,
-            HashMap<String, String> environment, ArrayList<String> command,
-            HashMap<String, String> byproducts) {
+            HashMap<String, Object> environment, ArrayList<String> command,
+            HashMap<String, Object> byproducts) {
 
         super();
 
@@ -40,13 +40,13 @@ class LinkSignable
            name = "step";
 
         if (environment == null)
-            environment = new HashMap<String, String>();
+            environment = new HashMap<String, Object>();
 
         if (command == null)
             command = new ArrayList<String>();
 
         if (byproducts == null)
-            byproducts = new HashMap<String, String>();
+            byproducts = new HashMap<String, Object>();
 
         this.materials = materials;
         this.products = products;

--- a/src/main/java/io/github/in_toto/models/Metablock.java
+++ b/src/main/java/io/github/in_toto/models/Metablock.java
@@ -131,7 +131,7 @@ abstract class Metablock<S extends Signable>
         }
 
         keyid = privateKey.computeKeyId();
-        payload = this.signed.JSONEncode().getBytes();
+        payload = this.signed.JSONEncodeCanonical().getBytes();
 
         Signer signer = privateKey.getSigner();
         signer.init(true, keyParameters);

--- a/src/main/java/io/github/in_toto/models/Metablock.java
+++ b/src/main/java/io/github/in_toto/models/Metablock.java
@@ -12,12 +12,17 @@ import io.github.in_toto.models.Signable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
 
 import org.bouncycastle.crypto.Signer;
 import org.bouncycastle.util.encoders.Hex;
 import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
 import org.bouncycastle.crypto.CryptoException;
 
+import java.lang.reflect.Type;
 /**
  * A metablock class that contains two elements
  *
@@ -80,7 +85,27 @@ abstract class Metablock<S extends Signable>
      * @return a JSON string representation of the metadata instance
      */
     public String dumpString() {
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        Gson gson = new GsonBuilder()
+                // Override gson serializer to convert all numbers to
+                // non-floating point numbers, as we don't allow floating point
+                // numbers in the reference implementation.
+                // This is required to handle generic data, such as
+                // `byproducts` or `environment`, where we don't declare the
+                // type of the contained values. Gson treats any numeric value
+                // where the type is not specified in the target data structure
+                // as double.
+                .registerTypeAdapter(Double.class, new JsonSerializer<Double>() {
+                        @Override
+                        public JsonElement serialize(
+                                Double src, Type typeOfSrc,
+                                JsonSerializationContext context) {
+                            if(src == src.longValue())
+                                return new JsonPrimitive(src.longValue());
+                            return new JsonPrimitive(src);
+                            }
+                        })
+                .setPrettyPrinting()
+                .create();
         return gson.toJson(this);
     }
 

--- a/src/main/java/io/github/in_toto/models/Metablock.java
+++ b/src/main/java/io/github/in_toto/models/Metablock.java
@@ -9,20 +9,16 @@ import java.io.IOException;
 import io.github.in_toto.keys.Key;
 import io.github.in_toto.keys.Signature;
 import io.github.in_toto.models.Signable;
+import io.github.in_toto.lib.NumericJSONSerializer;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonSerializer;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonPrimitive;
 
 import org.bouncycastle.crypto.Signer;
 import org.bouncycastle.util.encoders.Hex;
 import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
 import org.bouncycastle.crypto.CryptoException;
 
-import java.lang.reflect.Type;
 /**
  * A metablock class that contains two elements
  *
@@ -86,24 +82,8 @@ abstract class Metablock<S extends Signable>
      */
     public String dumpString() {
         Gson gson = new GsonBuilder()
-                // Override gson serializer to convert all numbers to
-                // non-floating point numbers, as we don't allow floating point
-                // numbers in the reference implementation.
-                // This is required to handle generic data, such as
-                // `byproducts` or `environment`, where we don't declare the
-                // type of the contained values. Gson treats any numeric value
-                // where the type is not specified in the target data structure
-                // as double.
-                .registerTypeAdapter(Double.class, new JsonSerializer<Double>() {
-                        @Override
-                        public JsonElement serialize(
-                                Double src, Type typeOfSrc,
-                                JsonSerializationContext context) {
-                            if(src == src.longValue())
-                                return new JsonPrimitive(src.longValue());
-                            return new JsonPrimitive(src);
-                            }
-                        })
+                // Use custom serializer to enforce non-floating point numbers
+                .registerTypeAdapter(Double.class, new NumericJSONSerializer())
                 .setPrettyPrinting()
                 .create();
         return gson.toJson(this);

--- a/src/main/java/io/github/in_toto/models/Metablock.java
+++ b/src/main/java/io/github/in_toto/models/Metablock.java
@@ -127,4 +127,14 @@ abstract class Metablock<S extends Signable>
         this.signatures.add(new Signature(keyid, sig));
 
     }
+
+    /**
+     * Public shortcut to call JSONEncodeCanonical on the signed field of
+     * this metablock.
+     *
+     * @param serializeNulls
+     */
+    public String getCanonicalJSON(boolean serializeNulls) {
+        return this.signed.JSONEncodeCanonical(serializeNulls);
+    }
 }

--- a/src/main/java/io/github/in_toto/models/Metablock.java
+++ b/src/main/java/io/github/in_toto/models/Metablock.java
@@ -82,6 +82,7 @@ abstract class Metablock<S extends Signable>
      */
     public String dumpString() {
         Gson gson = new GsonBuilder()
+                .serializeNulls()
                 // Use custom serializer to enforce non-floating point numbers
                 .registerTypeAdapter(Double.class, new NumericJSONSerializer())
                 .setPrettyPrinting()

--- a/src/test/java/io/github/in_toto/TestJSONCanonical.java
+++ b/src/test/java/io/github/in_toto/TestJSONCanonical.java
@@ -1,0 +1,35 @@
+import io.github.in_toto.models.Link;
+import java.io.*;
+import java.nio.file.*;
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TestJSONCanonical {
+    @Test
+    public void testCanonicalJSONEdgeCases () throws IOException {
+        // from securesystemslib.formats import encode_canonical
+        // from in_toto.models.metadata import Metablock
+        // linkMb = Metablock.load("src/test/resources/testvalues.link")
+        // encode_canonical(
+        //      linkMb.signed.signable_dict).encode("UTF-8").hex()
+        String referenceCanonicalLinkHex = "7b225f74797065223a226c696e6b222" +
+                "c22627970726f6475637473223a7b7d2c22636f6d6d616e64223a5b5d2" +
+                "c22656e7669726f6e6d656e74223a7b2261223a22575446222c2262223" +
+                "a747275652c2263223a66616c73652c2264223a6e756c6c2c2265223a3" +
+                "12c2266223a221befbfbf465c5c6e5c22227d2c226d6174657269616c7" +
+                "3223a7b7d2c226e616d65223a2274657374222c2270726f64756374732" +
+                "23a7b7d7d";
+
+        // Load test link with special values (edge cases) in opaque
+        // environment field
+        String linkString = new String(Files.readAllBytes(
+                Paths.get("src/test/resources/testvalues.link")));
+        Link link = Link.read(linkString);
+
+        // Assert that Java's canonical json representation of the link is
+        // equal to reference implementation's canonical json representation
+        assertEquals(Hex.toHexString(link.getCanonicalJSON(true).getBytes()),
+                referenceCanonicalLinkHex);
+    }
+}

--- a/src/test/java/io/github/in_toto/models/LinkTest.java
+++ b/src/test/java/io/github/in_toto/models/LinkTest.java
@@ -104,7 +104,7 @@ class LinkTest
     @DisplayName("Validate Link setByproducts")
     public void testValidByproduct()
     {
-        HashMap<String, String> byproduct = new HashMap<>();
+        HashMap<String, Object> byproduct = new HashMap<>();
         byproduct.put("stdin","");
         link.setByproducts(byproduct);
         assertEquals(byproduct, link.getByproducts());
@@ -114,7 +114,7 @@ class LinkTest
     @DisplayName("Validate Link setEnvironments")
     public void testValidEnvironment()
     {
-        HashMap<String, String> environment = new HashMap<>();
+        HashMap<String, Object> environment = new HashMap<>();
         environment.put("variables", "<ENV>");
         link.setEnvironment(environment);
         assertEquals(environment, link.getEnvironment());

--- a/src/test/resources/testvalues.link
+++ b/src/test/resources/testvalues.link
@@ -1,0 +1,14 @@
+{
+ "signatures": [], "signed": {
+    "_type": "link", "name": "test", "command": [],
+    "byproducts": {},"products": {}, "materials": {},
+    "environment": {
+      "a": "WTF",
+      "b": true,
+      "c": false,
+      "d": null,
+      "e": 1,
+      "f": "\u001b\uFFFFF\\n\""
+    }
+  }
+}


### PR DESCRIPTION
Quick-fixes #11 

This fixes issues with compatibility with the Python reference implementation by porting the reference implementation json canonicalization function, based on the [OLPC specification](http://wiki.laptop.org/go/Canonical_JSON).
