### PR TITLE
Removed unused property and adds new release flow for deploying to Maven Central

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,22 @@
+name: Publish package to the Maven Central Repository
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Maven Central Repository
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+        server-id: ossrh
+        server-username: MAVEN_USERNAME
+        server-password: MAVEN_PASSWORD
+    - name: Publish package
+      run: mvn --batch-mode deploy
+      env:
+        MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/src/main/java/io/github/intoto/models/DigestSetAlgorithmType.java
+++ b/src/main/java/io/github/intoto/models/DigestSetAlgorithmType.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 /** Helper Enum with common algorithm types, could be used to populate the {@link Subject} digest */
 public enum DigestSetAlgorithmType {
-  @JsonProperty("sha256")
   SHA256("sha256"),
   SHA224("sha224"),
   SHA384("sha384"),


### PR DESCRIPTION
This change contains:

* A release.yaml Github Action that pushes to Maven Central as per: https://docs.github.com/en/actions/publishing-packages/publishing-java-packages-with-maven
* Removes an unused annotation.