### PR TITLE
workflows:release: add gpg signing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,9 @@ jobs:
         server-id: ossrh
         server-username: MAVEN_USERNAME
         server-password: MAVEN_PASSWORD
+    - name: Install GPG secret key
+      run: |
+          cat <(echo -e "${{ secrets.GPG_PRIVATE_KEY }}") | gpg --batch --import
     - name: Publish package
       run: mvn --batch-mode deploy
       env:


### PR DESCRIPTION
Our releases are being rejected due to lack of gpg signatures on the
POM. Use the Github secret key provided to sign the artifacts prior to
publishing.