### PR TITLE
removed the usage of regex library

### DIFF
--- a/src/main/java/io/github/intoto/legacy/lib/JSONEncoder.java
+++ b/src/main/java/io/github/intoto/legacy/lib/JSONEncoder.java
@@ -28,8 +28,7 @@ public interface JSONEncoder {
    * @return A canonicalized String
    */
   static String canonicalizeString(String src) {
-    String pattern = "([\\\\\"])";
-    return String.format("\"%s\"", src.replaceAll(pattern, "\\\\$1"));
+    return String.format("\"%s\"", src.replace("\\", "\\\\").replace("\"","\\\""));
   }
 
   /**


### PR DESCRIPTION
Fixes #37 
Replaced the function `replaceALL()` with `replace()`
`replaceAll` uses a regex on each call while compiling whereas `replace()` uses a non-regex string replacment which is fater.