### PR TITLE
produce DSSE Envelope for Link Metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,12 @@
       <artifactId>jakarta.el</artifactId>
       <version>4.0.2</version>
     </dependency>
+    <!-- sigstore-java -->
+    <dependency>
+      <groupId>dev.sigstore</groupId>
+      <artifactId>sigstore-java</artifactId>
+      <version>0.10.0</version>
+    </dependency>
 
   </dependencies>
   <properties>

--- a/src/test/java/io/github/intoto/helpers/provenancev01/IntotoHelperTest.java
+++ b/src/test/java/io/github/intoto/helpers/provenancev01/IntotoHelperTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import dev.sigstore.KeylessSignerException;
 import io.github.intoto.dsse.helpers.SimpleECDSASigner;
 import io.github.intoto.dsse.helpers.SimpleECDSAVerifier;
 import io.github.intoto.dsse.models.IntotoEnvelope;
@@ -25,14 +26,10 @@ import io.github.intoto.slsa.models.v01.Provenance;
 import io.github.intoto.slsa.models.v01.Recipe;
 import io.github.intoto.utilities.provenancev01.IntotoStubFactory;
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.security.InvalidKeyException;
-import java.security.KeyPair;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.Security;
-import java.security.SignatureException;
+import java.security.*;
+import java.security.cert.CertificateException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -566,8 +563,8 @@ public class IntotoHelperTest {
   @DisplayName("Test creating envelope from Statement")
   public void
       produceIntotoEnvelopeAsJson_shouldCorrectlyCreateAnEnvelope_whenCompleteStatementIsPassed()
-          throws InvalidModelException, JsonProcessingException, NoSuchAlgorithmException,
-              SignatureException, InvalidKeyException {
+          throws InvalidModelException, IOException, NoSuchAlgorithmException,
+          SignatureException, InvalidKeyException, InvalidAlgorithmParameterException, CertificateException, KeylessSignerException {
     // ** The subject  **
     Subject subject = new Subject();
     subject.setName("curl-7.72.0.tar.bz2");

--- a/src/test/java/io/github/intoto/helpers/provenancev02/IntotoHelperTest.java
+++ b/src/test/java/io/github/intoto/helpers/provenancev02/IntotoHelperTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import dev.sigstore.KeylessSignerException;
 import io.github.intoto.dsse.helpers.SimpleECDSASigner;
 import io.github.intoto.dsse.helpers.SimpleECDSAVerifier;
 import io.github.intoto.dsse.models.IntotoEnvelope;
@@ -22,14 +23,10 @@ import io.github.intoto.models.Subject;
 import io.github.intoto.slsa.models.v02.*;
 import io.github.intoto.utilities.provenancev02.IntotoStubFactory;
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.security.InvalidKeyException;
-import java.security.KeyPair;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.Security;
-import java.security.SignatureException;
+import java.security.*;
+import java.security.cert.CertificateException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -577,8 +574,8 @@ public class IntotoHelperTest {
   @DisplayName("Test creating envelope from Statement")
   public void
       produceIntotoEnvelopeAsJson_shouldCorrectlyCreateAnEnvelope_whenCompleteStatementIsPassed()
-          throws InvalidModelException, JsonProcessingException, NoSuchAlgorithmException,
-              SignatureException, InvalidKeyException {
+          throws InvalidModelException, IOException, NoSuchAlgorithmException,
+          SignatureException, InvalidKeyException, InvalidAlgorithmParameterException, CertificateException, KeylessSignerException {
     // ** The subject  **
     Subject subject = new Subject();
     subject.setName("curl-7.72.0.tar.bz2");

--- a/src/test/java/io/github/intoto/helpers/provenancev1/IntotoHelperTest.java
+++ b/src/test/java/io/github/intoto/helpers/provenancev1/IntotoHelperTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import dev.sigstore.KeylessSignerException;
 import io.github.intoto.dsse.helpers.SimpleECDSASigner;
 import io.github.intoto.dsse.helpers.SimpleECDSAVerifier;
 import io.github.intoto.dsse.models.IntotoEnvelope;
@@ -27,14 +28,10 @@ import io.github.intoto.slsa.models.v1.ResourceDescriptor;
 import io.github.intoto.slsa.models.v1.RunDetails;
 import io.github.intoto.utilities.provenancev1.IntotoStubFactory;
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.security.InvalidKeyException;
-import java.security.KeyPair;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.Security;
-import java.security.SignatureException;
+import java.security.*;
+import java.security.cert.CertificateException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -600,8 +597,8 @@ public class IntotoHelperTest {
   @DisplayName("Test creating envelope from Statement")
   public void
       produceIntotoEnvelopeAsJson_shouldCorrectlyCreateAnEnvelope_whenCompleteStatementIsPassed()
-          throws InvalidModelException, JsonProcessingException, NoSuchAlgorithmException,
-              SignatureException, InvalidKeyException {
+          throws InvalidModelException, IOException, NoSuchAlgorithmException,
+          SignatureException, InvalidKeyException, InvalidAlgorithmParameterException, CertificateException, KeylessSignerException {
     // ** The subject  **
     Subject subject = new Subject();
     subject.setName("curl-7.72.0.tar.bz2");


### PR DESCRIPTION
This pull request produces DSSE Envelope for Link metadata and refactors the code to avoid repetition by adding `createAndFillEnvelope` method to create `IntotoEnvelope` and `setKeyId`, `setSignature`  for the envelope  